### PR TITLE
Fix path to status json for zuul.o.o

### DIFF
--- a/osjktw/__init__.py
+++ b/osjktw/__init__.py
@@ -23,7 +23,7 @@ def tweet():
     api = twitter.Api(**creds)
 
     try:
-        req = get("http://zuul.openstack.org/status")
+        req = get("http://zuul.openstack.org/api/status")
         content = json.loads(req.text)
 
         check_jobs = None


### PR DESCRIPTION
With the zuul dashboard for zuul.o.o, we need to fix up the URL we are
using to fetch pipeline information.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>